### PR TITLE
Update esprima to version 3.1.3

### DIFF
--- a/lib/get-wrapper.js
+++ b/lib/get-wrapper.js
@@ -156,8 +156,9 @@ function getWrapper(ast, getReturn, moveStrictWanted) {
 }
 
 module.exports = function (code, getReturn, moveStrictWanted) {
+  var options = moveStrictWanted ? { range: true, tolerant: true } : { range: true };
   try {
-    var ast = parse(code, { range: true });
+    var ast = parse(code, options);
     return getWrapper(ast, getReturn, moveStrictWanted);
   } catch (e) {
     log.error('get-wrapper', 'error while extracting wrapper', e);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "cardinal": "~0.5.0",
-    "esprima": "~1.1.1",
+    "esprima": "~3.1.3",
     "estraverse": "~4.0.0",
     "map-stream": "0.0.5",
     "npmlog": "~1.2.0",

--- a/test/fixtures/es6.js
+++ b/test/fixtures/es6.js
@@ -1,0 +1,27 @@
+define([ 'director' ], function (director) {
+  var currentNav = null;
+
+  var someObject = {
+    funcName() {
+      // this should work
+    }
+  }
+
+    // MDN example
+  function Person(){
+    this.age = 0;
+
+    setInterval(() => {
+      this.age++; // |this| properly refers to the person object
+    }, 1000);
+  }
+
+  var p = new Person();
+
+  'use strict';
+  return {
+      github        :  github.init
+    , blog          :  blog.init
+    , about         :  about.init
+  };
+});

--- a/test/fixtures/es6.upgraded.js
+++ b/test/fixtures/es6.upgraded.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var director = require('./resolved/director');
+
+var currentNav = null;
+
+var someObject = {
+  funcName() {
+    // this should work
+  }
+}
+
+  // MDN example
+function Person(){
+  this.age = 0;
+
+  setInterval(() => {
+    this.age++; // |this| properly refers to the person object
+  }, 1000);
+}
+
+var p = new Person();
+
+module.exports = {
+    github        :  github.init
+  , blog          :  blog.init
+  , about         :  about.init
+};

--- a/test/fixtures/use-strict-without-semicolon.js
+++ b/test/fixtures/use-strict-without-semicolon.js
@@ -7,5 +7,5 @@ define([ 'director' ], function (director) {
       github        :  github.init
     , blog          :  blog.init
     , about         :  about.init
-  }
+  };
 })

--- a/test/fixtures/use-strict-without-semicolon.upgraded.js
+++ b/test/fixtures/use-strict-without-semicolon.upgraded.js
@@ -8,4 +8,4 @@ module.exports = {
     github        :  github.init
   , blog          :  blog.init
   , about         :  about.init
-}
+};

--- a/test/upgrade.js
+++ b/test/upgrade.js
@@ -66,6 +66,7 @@ function run(t, fixture, opts) {
 , [ 'upgrades code with use strict in the middle of the module'                            , 'use-strict-in-middle' ]
 , [ 'upgrades code with use strict at end of the module'                                   , 'use-strict-at-bottom' ]
 , [ 'upgrades code with use strict without semicolon'                                      , 'use-strict-without-semicolon' ]
+, [ 'upgrades code with es6 styles'                                                        , 'es6' ]
 ].forEach(function (testcase) {
     test('\n' + testcase[0], function (t) {
       run(t, testcase[1], testcase[2])


### PR DESCRIPTION
I have to fix this broken test `test/fixtures/use-strict-without-semicolon.js`
Since using `use strict` it was throwing an error when parsing the code about
missing semicolon here

closes #21 